### PR TITLE
feat: allow to skip some reading errors

### DIFF
--- a/adc_ads111x_i2cTypes.hpp
+++ b/adc_ads111x_i2cTypes.hpp
@@ -1,12 +1,7 @@
 #ifndef adc_ads111x_i2c_TYPES_HPP
 #define adc_ads111x_i2c_TYPES_HPP
 
-/* If you need to define types specific to your oroGen components, define them
- * here. Required headers must be included explicitly
- *
- * However, it is common that you will only import types from your library, in
- * which case you do not need this file
- */
+#include <cstdint>
 
 namespace adc_ads111x_i2c {
     /** Input configuration
@@ -50,6 +45,11 @@ namespace adc_ads111x_i2c {
         Input input;
         Range range;
         Rate rate;
+
+        /** How many times in a row the component can have read errors on this
+         * input until it bails out with IO_ERROR
+         */
+        uint8_t acceptable_errors = 0;
     };
 }
 

--- a/adc_ads111x_i2cTypes.hpp
+++ b/adc_ads111x_i2cTypes.hpp
@@ -1,7 +1,7 @@
 #ifndef adc_ads111x_i2c_TYPES_HPP
 #define adc_ads111x_i2c_TYPES_HPP
 
-#include <cstdint>
+#include <stdint.h>
 
 namespace adc_ads111x_i2c {
     /** Input configuration

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -30,10 +30,14 @@ namespace adc_ads111x_i2c{
         int mFD = -1;
 
         std::vector<Reading> mReadings;
-        std::vector<i2c_msg> mTransaction;
+        std::vector<uint8_t> mErrorCount;
         std::vector<raw_io::Analog> mOutput;
 
+        enum Result { OK, ERROR, SKIP };
+
+        Result handleError(bool success, size_t readingIndex);
         bool configureReading(Reading const& reading);
+        bool triggerReading();
         std::pair<bool, uint16_t> readRegister(uint8_t index);
         bool writeRegister(uint8_t index, uint16_t value);
 

--- a/tasks/adctest.cpp
+++ b/tasks/adctest.cpp
@@ -60,8 +60,8 @@ enum Rate {
 
 struct Reading {
     Input input;
-    Range range;
-    Rate rate;
+    Range range = RANGE_6144mV;
+    Rate rate = RATE_64HZ;
 };
 
 bool configureReading(int fd, Reading const& reading);


### PR DESCRIPTION
i2c as a hardware protocol is rather sensitive to noise, and turns
out that we do have that problem. This commit allows to skip some
errors if they do not happen in a row.

The effect on timing will be determined by the configured timeout.